### PR TITLE
Provide Better Error Data on Bad Post Request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist/
 build/
 *.egg-info/
 __pycache__
+jeff.py
+*/venv/

--- a/btcpay/client.py
+++ b/btcpay/client.py
@@ -5,6 +5,7 @@ BTCPay API Client.
 
 import re
 import json
+from urllib.error import HTTPError
 from urllib.parse import urlencode
 
 import requests
@@ -52,7 +53,13 @@ class BTCPayClient:
         payload = json.dumps(payload)
         headers = self._create_signed_headers(uri, payload)
         r = self.s.post(uri, headers=headers, data=payload)
-        r.raise_for_status()
+        if not r.ok:
+            raise Exception(
+                'Response Code: ' +
+                str(r.status_code) + ' ' +
+                str(r.reason) +
+                str(r.text)
+            )
         return r.json()['data']
 
     def _unsigned_request(self, path, payload=None):

--- a/btcpay/client.py
+++ b/btcpay/client.py
@@ -5,7 +5,6 @@ BTCPay API Client.
 
 import re
 import json
-from urllib.error import HTTPError
 from urllib.parse import urlencode
 
 import requests

--- a/btcpay/client.py
+++ b/btcpay/client.py
@@ -8,6 +8,7 @@ import json
 from urllib.parse import urlencode
 
 import requests
+from requests.exceptions import HTTPError
 
 from . import crypto
 
@@ -53,12 +54,24 @@ class BTCPayClient:
         headers = self._create_signed_headers(uri, payload)
         r = self.s.post(uri, headers=headers, data=payload)
         if not r.ok:
-            raise Exception(
-                'Response Code: ' +
-                str(r.status_code) + ' ' +
-                str(r.reason) +
-                str(r.text)
-            )
+            if 400 <= r.status_code < 500:
+                http_error_msg = u'%s Client Error: \
+                        %s for url: %s | body: %s' % (
+                            r.status_code,
+                            r.reason,
+                            r.url,
+                            r.text
+                        )
+            elif 500 <= r.status_code < 600:
+                http_error_msg = u'%s Server Error: \
+                        %s for url: %s | body: %s' % (
+                            r.status_code,
+                            r.reason,
+                            r.url,
+                            r.text
+                        )
+            if http_error_msg:
+                raise HTTPError(http_error_msg, response=r)
         return r.json()['data']
 
     def _unsigned_request(self, path, payload=None):


### PR DESCRIPTION
Currently when the client's _signed_post_request function is rejected by the server, it calls raise_for_status.

Unfortunately raise_for_status() only gives the error code and "reason"; it excludes the additional data that BTCPay provides in the body of the response. This additional data is very useful for troubleshooting.

Example: Recently when using the create_invoice function, I was getting 400 responses back from BTCPay and couldn't figure out why. The python traceback gave only the 400 response and "reason" (bad request to /invoices/). The underlying reason for the 400 response was that like a buffoon I had no derivation scheme set in BTCPay. This would've been an easy fix, especially since the body of the response gave this information. However, since raise_for_status ignores the response body, I didn't have this info.

This PR changes the behavior so that instead of using raise_for_status(), the function instead creates a full-blown Exception which logs to the traceback:

- HTTP Error Code
- Reason
- A string printout of the response body from BTCPay

The response body will provide valuable troubleshooting info.