### PR TITLE
Prepare Prior PR #4 for PyPI to Make It Installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 __pycache__
 jeff.py
 */venv/
+data

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ pip3 install btcpay
 ```python
 client = BTCPayClient.create_client(host='https://btcpay.example.com', code=<pairing-code>)
 ```
+* The client can be stored to persistent storage for later use. This could, for example, be accomplished by [pickling](https://docs.python.org/3.5/library/pickle.html) the client object and saving the pickled object to Redis, or alternatively saving as a PickleType in sqlalchemy.
 
 ## Creating a client the manual way (not necessary if you used the 'easy' method)
 * Generate and save private key:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ pip3 install btcpay
 ```python
 client = BTCPayClient.create_client(host='https://btcpay.example.com', code=<pairing-code>)
 ```
-* The client can be stored to persistent storage for later use. This could, for example, be accomplished by [pickling](https://docs.python.org/3.5/library/pickle.html) the client object and saving the pickled object to Redis, or alternatively saving as a PickleType in sqlalchemy.
+
 
 ## Creating a client the manual way (not necessary if you used the 'easy' method)
 * Generate and save private key:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,14 @@
 pip3 install btcpay
 ```
 
+## The "easy method" to create a new BTCPay client
+* On BTCPay server > shop > access tokens > create new token, copy pairing code.
+* Then use that code in the below Python code:
+```python
+client = BTCPayClient.create_client(host='https://btcpay.example.com', code=<pairing-code>)
+```
 
-## Pairing
+## Creating a client the manual way (not necessary if you used the 'easy' method)
 * Generate and save private key:
 ```python
 import btcpay.crypto
@@ -32,15 +38,6 @@ client = BTCPayClient(
 )
 ```
 
-
-## Creating a client
-```python
-client = BTCPayClient(
-    host='http://hostname',
-    pem=privkey,
-    tokens={'merchant': "xdr9vw3v5wc0w90859v45"}
-)
-```
 
 ## Get rates
 ```python

--- a/btcpay/client.py
+++ b/btcpay/client.py
@@ -119,6 +119,13 @@ class BTCPayClient:
             data['facade']: data['token']
         }
 
+    @classmethod
+    def create_client(cls, code, host):
+        pem = crypto.generate_privkey()
+        client = BTCPayClient(host=host, pem=pem)
+        token = client.pair_client(code)
+        return BTCPayClient(host=host, pem=pem, tokens=token)
+
     def __repr__(self):
         return '{}({})'.format(
             type(self).__name__,

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,12 @@ from setuptools import setup, find_packages
 setup(
     name="btcpay",
     packages=find_packages(),
-    version="1.0.3",
+    version="1.0.4",
     description="Accept bitcoin with BTCPay",
     author="Joe Black",
     author_email="me@joeblack.nyc",
-    url="https://github.com/joeblackwaslike/btcpay-python",
-    download_url="https://github.com/joeblackwaslike/btcpay-python/tarball/v1.0.3",
+    url="https://github.com/btcpayserver/btcpay-python",
+    download_url="https://github.com/btcpayserver/btcpay-python/archive/v1.0.3.tar.gz",
     license='MIT',
     keywords=["bitcoin", "payments", "crypto"],
     install_requires=[


### PR DESCRIPTION
I apologize in advance if I'm being jerk and over-explaining! Since BTCPay is a C# project I wrote this assuming the reader as has zero Python knowledge.

This PR accomplishes some housekeeping:

1. Prior PR #4 was merged, but the changes in #4 are not available to Python developers using the library through its primary install method (pip). In order to make the updated library available in pip, a new package must be created, and the package must be uploaded to PyPI. The changes to `setup.py` in this PR are the changes necessary to create a new version of  the package for pip/PyPI. In addition to bumping the version number, in `setup.py` I also changed the PyPI reference URLs away from the unofficial joeblackwaslike repository to the official BTCPay repository. I left the `author` and `author-email` tags as Joe Black, but I can change those to "BTCPay" or something if preferred.

2. If this new PR is merged, after the merge is complete, it should be tagged as version 1.0.4 so that github versioning matches PyPI versioning.

3. If this new PR is merged, after the merge is complete, whoever controls the PyPI upload credentials would need to upload the new version of the package to PyPI.

4. This PR also adds a `classmethod` called `create_client` that reduces the number of lines of code to create a new BTCPay client object from 4 down to 1. It does not break any compatability, as the prior constructor method and pairing methods remain in place. Developers can still choose to create client objects using the older, longer method. The new `classmethod` is simply a convenience function that bundles the other existing methods together into one line of code. The README is also updated to reflect both the new and old ways of creating client objects.
