### PR TITLE
Support for SATS token as currency.

### DIFF
--- a/btcpay/client.py
+++ b/btcpay/client.py
@@ -98,7 +98,7 @@ class BTCPayClient:
         return rate['rate']
 
     def create_invoice(self, payload, token=None):
-        if re.match(r'^[A-Z]{3,3}$', payload['currency']) is None:
+        if re.match(r'^(?:[A-Z]{3,3}|SATS)$', payload['currency']) is None:
             raise ValueError('Currency is invalid.')
         try:
             float(payload['price'])


### PR DESCRIPTION
Per [PR 1041](https://github.com/btcpayserver/btcpayserver/pull/1041) of the main BTCPayServer Repo, "SATS" (for satoshis) is now supported as a main currency token.

This causes a breaking issue with this Python client library, as the regex check for a valid currency requires that the currency token be three characters long, no longer or shorter.

This PR adds a single exception for the "SATS" token as a valid, accepted currency in BTCPayServer.