### PR TITLE
Add tor-client support

### DIFF
--- a/btcpay/client.py
+++ b/btcpay/client.py
@@ -144,6 +144,7 @@ class BTCPayClient:
         token = client.pair_client(code)
         return BTCPayClient(host=host, pem=pem, tokens=token)
 
+    @classmethod
     def create_tor_client(cls, code, host, proxy='socks5://127.0.0.1:9050'):
         """ Useful for .onion services, the `proxy` input assumes the default
         proxy header

--- a/btcpay/client.py
+++ b/btcpay/client.py
@@ -144,6 +144,23 @@ class BTCPayClient:
         token = client.pair_client(code)
         return BTCPayClient(host=host, pem=pem, tokens=token)
 
+    def create_tor_client(cls, code, host, proxy='socks5://127.0.0.1:9050'):
+        """ Useful for .onion services, the `proxy` input assumes the default
+        proxy header
+        """
+        pem = crypto.generate_privkey()
+        client = BTCPayClient(host=host, pem=pem)
+        client.s.proxies = {
+            'http': proxy,
+            'https': proxy}
+        token = client.pair_client(code)
+        final_client = BTCPayClient(host=host, pem=pem, tokens=token)
+        final_client.s.proxies = {
+            'http': proxy,
+            'https': proxy}
+        return final_client
+
+
     def __repr__(self):
         return '{}({})'.format(
             type(self).__name__,


### PR DESCRIPTION
As it turns out, the python `requests` library supports using the TOR service as a proxy, and when using the service, it can reach out to .onion hidden services.

This PR gives the option to create a TOR client to reach out into BTCPayServer instances behind .onion hidden services, as long as Tor is already running on the client machine.